### PR TITLE
Updated archetype-plugins for slim3-1.0.16, appengine-1.7.5

### DIFF
--- a/slim3-archetype-kotori-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/slim3-archetype-kotori-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -8,7 +8,7 @@
   <version>${version}</version>
   <properties>
     <slim3.version>1.0.16</slim3.version>
-    <appengine.version>1.7.0</appengine.version>
+    <appengine.version>1.7.5</appengine.version>
     <generated.src>.apt_generated</generated.src>
     <generated.war>war</generated.war>
     <eclipse.lib>eclipse.lib</eclipse.lib>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>
@@ -115,7 +115,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>apt-maven-plugin</artifactId>
-          <version>1.0-alpha-3</version>
+          <version>1.0-alpha-5</version>
           <dependencies>
             <dependency>
               <groupId>org.slim3</groupId>
@@ -157,7 +157,7 @@
         <artifactId>apt-maven-plugin</artifactId>
         <configuration>
           <encoding>utf-8</encoding>
-          <outputDirectory>${dollar}${lcurly}generated.src}</outputDirectory>
+          <sourceOutputDirectory>${dollar}${lcurly}generated.src}</sourceOutputDirectory>
         </configuration>
         <executions>
           <execution>

--- a/slim3-archetype-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/slim3-archetype-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -8,7 +8,7 @@
   <version>${version}</version>
   <properties>
     <slim3.version>1.0.16</slim3.version>
-    <appengine.version>1.7.0</appengine.version>
+    <appengine.version>1.7.5</appengine.version>
     <generated.src>.apt_generated</generated.src>
     <generated.war>war</generated.war>
     <eclipse.lib>eclipse.lib</eclipse.lib>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -115,7 +115,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>apt-maven-plugin</artifactId>
-          <version>1.0-alpha-3</version>
+          <version>1.0-alpha-5</version>
           <dependencies>
             <dependency>
               <groupId>org.slim3</groupId>
@@ -157,7 +157,7 @@
         <artifactId>apt-maven-plugin</artifactId>
         <configuration>
           <encoding>utf-8</encoding>
-          <outputDirectory>${dollar}${lcurly}generated.src}</outputDirectory>
+          <sourceOutputDirectory>${dollar}${lcurly}generated.src}</sourceOutputDirectory>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
archetype-plugin でmvn projectとして生成した時の構成を現在の最新の状態に変更しました。
Java7対応準備のために、apt-maven-pluginのバージョンの更新も行なっています。
