### PR TITLE
Updated dependency appengine and gwt version.

### DIFF
--- a/slim3/pom.xml
+++ b/slim3/pom.xml
@@ -207,35 +207,35 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-labs</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-local-runtime</artifactId>
-      <version>1.7.0</version>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.7.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-stubs</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-servlet</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Eclipseのメタファイルは更新していません…。
mvn clean eclipse:clean eclipse:eclipse するとdiffが発生します。
