### PR TITLE
Fix meta class compiler error.

### DIFF
--- a/slim3-gen/src/main/java/org/slim3/gen/generator/ModelMetaGenerator.java
+++ b/slim3-gen/src/main/java/org/slim3/gen/generator/ModelMetaGenerator.java
@@ -2649,6 +2649,8 @@ public class ModelMetaGenerator implements Generator {
             String container = ArrayList;
             if (type instanceof SortedSetType) {
                 container = TreeSet;
+            } else if (type instanceof LinkedHashSetType) {
+                container = LinkedHashSet;
             } else if (type instanceof SetType) {
                 container = HashSet;
             } else if (type instanceof LinkedListType) {


### PR DESCRIPTION
LinkedHashSetがfieldにある場合、生成されたMetaクラスがコンパイルエラーになるのを修正。
