### PR TITLE
allocateId時にKeyをcacheしていた処理を削除した。

### DIFF
--- a/slim3/src/main/java/org/slim3/datastore/DatastoreUtil.java
+++ b/slim3/src/main/java/org/slim3/datastore/DatastoreUtil.java
@@ -70,19 +70,11 @@ public final class DatastoreUtil {
      */
     public static final int EXTRA_SIZE = 200;
 
-    private static final int KEY_CACHE_SIZE = 50;
-
     /**
      * The cache for {@link ModelMeta}.
      */
     protected static ConcurrentHashMap<String, ModelMeta<?>> modelMetaCache =
         new ConcurrentHashMap<String, ModelMeta<?>>(87);
-
-    /**
-     * The cache for the result of allocateIds().
-     */
-    protected static ConcurrentHashMap<String, Iterator<Key>> keysCache =
-        new ConcurrentHashMap<String, Iterator<Key>>(87);
 
     private static volatile boolean initialized = false;
 
@@ -105,13 +97,6 @@ public final class DatastoreUtil {
      */
     public static void clearActiveGlobalTransactions() {
         GlobalTransaction.clearActiveTransactions();
-    }
-
-    /**
-     * Clears the keys cache.
-     */
-    public static void clearKeysCache() {
-        keysCache.clear();
     }
 
     /**
@@ -148,15 +133,10 @@ public final class DatastoreUtil {
             throw new NullPointerException(
                 "The kind parameter must not be null.");
         }
-        Iterator<Key> keys = keysCache.get(kind);
-        if (keys != null && keys.hasNext()) {
-            return keys.next();
-        }
-        keys =
+        Iterator<Key> keys =
             FutureUtil
-                .getQuietly(allocateIdsAsync(ds, kind, KEY_CACHE_SIZE))
+                .getQuietly(allocateIdsAsync(ds, kind, 1))
                 .iterator();
-        keysCache.put(kind, keys);
         return keys.next();
     }
 

--- a/slim3/src/main/java/org/slim3/tester/AppEngineTester.java
+++ b/slim3/src/main/java/org/slim3/tester/AppEngineTester.java
@@ -494,7 +494,6 @@ public class AppEngineTester implements Delegate<Environment> {
             datastoreKeys.clear();
         }
         mailMessages.clear();
-        DatastoreUtil.clearKeysCache();
         NamespaceManager.set(null);
         ApiProxy.setDelegate(originalDelegate);
         if (!AppEngineUtil.isProduction()) {

--- a/slim3/src/test/java/org/slim3/datastore/DatastoreUtilTest.java
+++ b/slim3/src/test/java/org/slim3/datastore/DatastoreUtilTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -113,21 +112,8 @@ public class DatastoreUtilTest extends AppEngineTestCase {
      */
     @Test
     public void allocateId() throws Exception {
-        DatastoreUtil.keysCache.remove("Hoge");
         Key key = DatastoreUtil.allocateId(ds, "Hoge");
         assertThat(key, is(notNullValue()));
-        Iterator<Key> keys = DatastoreUtil.keysCache.get("Hoge");
-        assertThat(keys, is(notNullValue()));
-        for (int i = 0; i < 49; i++) {
-            DatastoreUtil.allocateId(ds, "Hoge");
-            assertThat(
-                DatastoreUtil.keysCache.get("Hoge"),
-                is(sameInstance(keys)));
-        }
-        DatastoreUtil.allocateId(ds, "Hoge");
-        assertThat(
-            DatastoreUtil.keysCache.get("Hoge"),
-            is(not(sameInstance(keys))));
     }
 
     /**


### PR DESCRIPTION
削除した理由は以下の通り。
1. Namespaceが考慮できておらず、別のNamespaceにデータを投入してしまう。
2. Keyをcacheすることに、特にメリットを感じない。

同じKindのEntityをloopで回して、1つずつputしているような場合は、効いてくるかもしれないが、
そもそも、そのような実装になっているのが、よろしくない。

参考URL
https://groups.google.com/forum/?hl=ja#!topic/slim3-user-japan/TclIQ_Lw2Ys
