### PR TITLE
Modelリスナー使用時のModelMeta生成バグの修正

### DIFF
--- a/slim3-gen-jsr269/src/main/java/org/slim3/gen/desc/ModelMetaDescFactory.java
+++ b/slim3-gen-jsr269/src/main/java/org/slim3/gen/desc/ModelMetaDescFactory.java
@@ -405,7 +405,7 @@ public class ModelMetaDescFactory {
             return;
         }
         TypeElement listenerEl =
-            processingEnv.getElementUtils().getTypeElement(listener.toString());
+            processingEnv.getElementUtils().getTypeElement(listener.getValue().toString());
         if (listenerEl.getKind() == ElementKind.INTERFACE) {
             throw new ValidationException(
                 MessageCode.SLIM3GEN1052,

--- a/slim3-gen-jsr269/src/test/java/org/slim3/gen/processor/ModelProcessorTest.java
+++ b/slim3-gen-jsr269/src/test/java/org/slim3/gen/processor/ModelProcessorTest.java
@@ -25,6 +25,7 @@ import org.slim3.gen.processor.ModelProcessor;
 import org.slim3.test.model.AttributeNotSupportedSampleModel;
 import org.slim3.test.model.AttributeParameterSampleModel;
 import org.slim3.test.model.BasicModel;
+import org.slim3.test.model.ListenerModel;
 import org.slim3.test.model.AttributeSampleModel;
 import org.slim3.test.model.ImplementComparableModel;
 import org.slim3.test.model.RefAModel;
@@ -51,6 +52,27 @@ public class ModelProcessorTest extends AptinaTestCase {
         compile();
         {
             String sourceName = "org.slim3.test.meta.BasicModelMeta";
+            @SuppressWarnings("unused")
+            String source = getGeneratedSource(sourceName);
+        }
+        assertThat(getCompiledResult(), is(true));
+    }
+
+        /**
+     * Test for generate Meta class of {@link ListenerModel}.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testForModelListener() throws Exception {
+        ModelProcessor processor = new ModelProcessor();
+        addProcessor(processor);
+
+        addCompilationUnit(ListenerModel.class);
+
+        compile();
+        {
+            String sourceName = "org.slim3.test.meta.ListenerModelMeta";
             @SuppressWarnings("unused")
             String source = getGeneratedSource(sourceName);
         }

--- a/slim3-gen-jsr269/src/test/java/org/slim3/test/model/ListenerModel.java
+++ b/slim3-gen-jsr269/src/test/java/org/slim3/test/model/ListenerModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.slim3.test.model;
+
+import com.google.appengine.api.datastore.Key;
+import org.slim3.datastore.Attribute;
+import org.slim3.datastore.Model;
+import org.slim3.datastore.ModelListener;
+
+/**
+ * @author vvakame
+ * 
+ */
+@Model(listener = ListenerModel.Listener.class)
+public class ListenerModel {
+    @Attribute(primaryKey = true)
+    Key key;
+
+    /**
+     * @return the key
+     */
+    public Key getKey() {
+        return key;
+    }
+
+    /**
+     * @param key
+     *            the key to set
+     */
+    public void setKey(Key key) {
+        this.key = key;
+    }
+
+    public static class Listener implements ModelListener<ListenerModel> {
+        @Override
+        public void prePut(ListenerModel model) {
+
+        }
+
+        @Override
+        public void postGet(ListenerModel model) {
+
+        }
+    }
+}


### PR DESCRIPTION
slim3-gen-jsr269で@Modelアノテーションにlistenerが設定されていたときにModelMetaの生成でNullPointerExceptionが発生し、ModelMetaの生成に失敗するバグを修正しました。
